### PR TITLE
Reduce code length by using more lodash methods

### DIFF
--- a/lib/compare.js
+++ b/lib/compare.js
@@ -44,22 +44,15 @@ var compareFiles = module.exports.compareFiles = function(files, done) {
  * from the corresponding object.
  */
 var compareObjects = module.exports.compareObjects = function(objects, files) {
-  var paths = objectsKeyPaths(objects);
+  var paths = _.map(objects, objectKeyPaths);
   var allPaths = _.uniq(_.flatten(paths));
   return _.zipWith(objects, paths, files, function(accu, value, index, group) {
     return {
       object: group[0],
-      missingKeys: diffValues(allPaths, group[1]),
+      missingKeys: _.difference(allPaths, group[1]),
       file: group[2]
     };
   });
-}
-
-/**
- * Creates an array of keypaths of all objects.
- */
-function objectsKeyPaths(objects) {
-  return _.map(objects, objectKeyPaths);
 }
 
 /**
@@ -88,37 +81,15 @@ function objectKeyPaths(object) {
 }
 
 /**
- * Returns an array with all keys in array1 that are missing in array2.
- */
-function diffValues(array1, array2) {
-  return _.difference(array1, array2);
-}
-
-/**
  * Looks for values for defined key in all objects.
  */
 function findAlternatives(diff, missingKey) {
   var alternatives = {};
   _.forEach(diff, function(result) {
-    var value = getValueByPath(result.object, missingKey);
+    var value = _.get(result.object, missingKey);
     if (value) {
       alternatives[result.file] = value;
     }
   });
   return alternatives;
-}
-
-/**
- * Returns the value using a keypath.
- *
- * Example:
- * ```
- * var object = {
- *   a: { b: { c: 'test' }}
- * }
- * getValueByPath(object, 'a.b''); // Returns `{ c: 'test' }`
- * ```
- */
-function getValueByPath(object, path) {
-  return _.get(object, path);
 }

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -22,27 +22,19 @@ var compareFiles = module.exports.compareFiles = function(files, done) {
   if (files.length === 0) return done(new Error('Require at least two files, found none'));
 
   // Load json files and parse them as regular objects
-  var objects = [];
-  _.forEach(files, function(filepath) {
-    objects.push(JSON.parse(fs.readFileSync(filepath, { encoding: 'utf-8' })));
+  var objects = _.map(files, function(filepath) {
+    return JSON.parse(fs.readFileSync(filepath, { encoding: 'utf-8' }));
   });
 
   // Compare all objects
-  var diff = compareObjects(objects);
-
-  // Add filepath to results
-  for (var i = 0; i < files.length; i++) {
-    diff[i].file = files[i];
-  }
+  var diff = compareObjects(objects, files);
 
   // Find alternatives for missing keys
   _.forEach(diff, function(result) {
-    _.forEach(result.missingKeys, function(missingKey) {
-      if (!result.alternatives) {
-        result.alternatives = {};
-      }
-      result.alternatives[missingKey] = findAlternatives(diff, missingKey);
-    });
+    var keys = result.missingKeys;
+    result.alternatives = _.zipObject(keys, _.map(keys, function(missingKey) {
+      return findAlternatives(diff, missingKey);
+    }));
   });
   done(null, diff);
 }
@@ -51,28 +43,23 @@ var compareFiles = module.exports.compareFiles = function(files, done) {
  * Returns a collection of arrays where each array contains all elements missing
  * from the corresponding object.
  */
-var compareObjects = module.exports.compareObjects = function(objects) {
+var compareObjects = module.exports.compareObjects = function(objects, files) {
   var paths = objectsKeyPaths(objects);
   var allPaths = _.uniq(_.flatten(paths));
-  var diffs = [];
-  for (var i = 0; i < objects.length; i++) {
-    diffs.push({
-      object: objects[i],
-      missingKeys: diffValues(allPaths, paths[i])
-    });
-  }
-  return diffs;
+  return _.zipWith(objects, paths, files, function(accu, value, index, group) {
+    return {
+      object: group[0],
+      missingKeys: diffValues(allPaths, group[1]),
+      file: group[2]
+    };
+  });
 }
 
 /**
  * Creates an array of keypaths of all objects.
  */
 function objectsKeyPaths(objects) {
-  var paths = [];
-  _.forEach(objects, function(object) {
-    paths.push(objectKeyPaths(object));
-  });
-  return paths;
+  return _.map(objects, objectKeyPaths);
 }
 
 /**
@@ -104,13 +91,7 @@ function objectKeyPaths(object) {
  * Returns an array with all keys in array1 that are missing in array2.
  */
 function diffValues(array1, array2) {
-  var diff = [];
-  _.forEach(array1, function(value) {
-    if (!_.includes(array2, value)) {
-      diff.push(value);
-    }
-  });
-  return diff;
+  return _.difference(array1, array2);
 }
 
 /**
@@ -139,15 +120,5 @@ function findAlternatives(diff, missingKey) {
  * ```
  */
 function getValueByPath(object, path) {
-  var props = path.split('.');
-  var value = object;
-  for (var i = 0; i < props.length; i++) {
-    if (i < props.length) {
-      if (value[props[i]] === undefined) {
-        return null;
-      }
-      value = value[props[i]];
-    }
-  }
-  return value;
+  return _.get(object, path);
 }


### PR DESCRIPTION
Nice work on the plugin. I find it very useful when working with angular-translate JSON files.

Upon reading the source code I thought that the could be written shorter when more lodash-methods would be used. This PR reduces the number of lines for `compare.js` from 153 to 124. It passes all tests and performs about the same (~50ms difference om my testsamples, which run 2.5s (`real` time)).
