### PR TITLE
Always exit with errors when comparison failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For options, you can also run help `$ comparejson --help`
     <tr>
       <td>--exit</td>
       <td>-e</td>
-      <td>Exits the process with error code 1 when an error was found.</td>
+      <td>Immediatly exits the process with error code 1 when an error was found.</td>
     </tr>
     <tr>
       <td>--separator</td>
@@ -51,16 +51,21 @@ For options, you can also run help `$ comparejson --help`
       For example, assume the files <code>user-en.json, user-nl.json, register-en.json, register-nl.json</code>; to split these files in two comparison groups "user" and "register" you can run <code>comparejson -s="-" ./*.json</code>.</td>
     </tr>
     <tr>
-      <td>--groupBy</td>
+      <td>--group-by</td>
       <td>-g</td>
       <td>Separates files in different copmarison groups using a regular expression. Only files within the same group are compared to one another.
       <br /><br />
       For example, assume the files <code>user-en.json, user-nl.json, register-en.json, register-nl.json</code>; to split these files in two comparison groups "user" and "register" you can run <code>comparejson -g="(.+)\-.[^\/]+.*" ./*.json</code>. Please note that this particular example can be achieved easier using the <code>--separator</code> option.</td>
     </tr>
     <tr>
-      <td>--ignoreUngrouped</td>
+      <td>--ignore-ungrouped</td>
       <td>-i</td>
-      <td>When using <code>--groupBy</code> or <code>--separator</code> all files not matching any group will be ignored by default. To change this behaviour and group all unmatched groups in a single group use <code>-i=false</code>.</td>
+      <td>When using <code>--group-by</code> or <code>--separator</code> all files not matching any group will be ignored by default. To change this behaviour and group all unmatched groups in a single group use <code>-i=false</code>.</td>
+    </tr>
+    <tr>
+      <td>--only-errors</td>
+      <td></td>
+      <td>Only display errors in the console.</td>
     </tr>
   </tbody>
 </table>

--- a/bin/compare.js
+++ b/bin/compare.js
@@ -23,6 +23,11 @@ var argv = require('yargs')
     describe: 'Exit with error code when object keys were are missing',
     type: 'boolean'
   })
+  .option('onlyErrors', {
+    describe: 'Display only errors',
+    default: false,
+    type: 'boolean'
+  })
   .check(function(args) {
     if (args.groupBy && args.separator) {
       throw new Error('Error: cannot use both --separator and --groupBy');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,3 +11,5 @@ gulp.task('test', function() {
       includeStackTrace: true
     }));
 });
+
+gulp.task('default', ['test'])

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -30,6 +30,7 @@ module.exports = function(files, options) {
     output: function(msg) { process.stdout.write(msg + '\n'); },
     error: function(msg) { process.stderr.write(msg + '\n'); }
   });
+  var exitCode = 0;
 
   // Compare files only against one another in the same group (if enabled)
   if (opts.groupBy || opts.separator) {
@@ -38,10 +39,14 @@ module.exports = function(files, options) {
     }
     var groups = compare.groupFilesBy(files, opts.groupBy, opts.ignoreUngrouped);
     _.forEach(groups, function(group) {
-      compareGroup(group, opts);
+      exitCode += compareGroup(group, opts);
     });
   } else {
-    compareGroup(files, opts);
+    exitCode = compareGroup(files, opts);
+  }
+
+  if (exitCode > 0) {
+    process.exit(1);
   }
 }
 
@@ -51,7 +56,7 @@ module.exports = function(files, options) {
 function compareGroup(files, opts) {
   var output = opts.output;
   var error = opts.error;
-  compare.compareFiles(files, function(err, results) {
+  return compare.compareFiles(files, function(err, results) {
     if (err) {
       throw err;
     }
@@ -76,6 +81,7 @@ function compareGroup(files, opts) {
     if (opts.exit && exitCode > 0) {
       process.exit(exitCode);
     }
-    return;
+
+    return exitCode;
   });
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -73,7 +73,7 @@ function compareGroup(files, opts) {
         });
         error('');
         exitCode = 1;
-      } else {
+      } else if(!opts.onlyErrors) {
         output(colors.info(colors.bold(result.file) + ' is complete\n'));
       }
     });

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -50,7 +50,8 @@ var compareFiles = module.exports.compareFiles = function(files, done) {
       return findAlternatives(diff, missingPath);
     }));
   });
-  done(null, diff);
+
+  return done(null, diff);
 }
 
 /**


### PR DESCRIPTION
First, thanks a lot for your lib 👍 

We would like to use your lib into our linter. 
The task have to run all comparaison and fail at the end if an error was found.
I add a new flag to print only errors.

Let me know if you have any recommendation.

Thanks