### PR TITLE
Added extracedKeysFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,10 @@ For options, you can also run help `$ comparejson --help`
       <td>-i</td>
       <td>When using <code>--group-by</code> or <code>--separator</code> all files not matching any group will be ignored by default. To change this behaviour and group all unmatched groups in a single group use <code>-i=false</code>.</td>
     </tr>
+    <tr>
+      <td>--extractedKeysFile</td>
+      <td>-k</td>
+      <td>This allow to provide a regexp for identifying file(s) that should be included in the comparison but for which no missing key should be identified. This can be usefull when generating a file with all translations keys detected in the code with e.g. a tool like ngx-translate-extract</td>
+    </tr>
   </tbody>
 </table>

--- a/bin/compare.js
+++ b/bin/compare.js
@@ -18,6 +18,11 @@ var argv = require('yargs')
     default: true,
     type: 'boolean'
   })
+  .option('extractedKeysFile', {
+    alias: 'k',
+    describe: 'Regular expression of file(s) containing keys detected in the code which should not be shown in the result.',
+    type: 'string'
+  })
   .option('exit', {
     alias: 'e',
     describe: 'Exit with error code when object keys were are missing',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -63,6 +63,12 @@ function compareGroup(files, opts) {
       throw err;
     }
 
+    if (opts.extractedKeysFile) {
+        results = results.filter((fileDiff) => {
+        return !new RegExp(opts.extractedKeysFile).test(fileDiff.file);
+      });
+    }
+
     var exitCode = 0;
     _.forEach(results, function(result) {
       if (result.missingPaths && result.missingPaths.length > 0) {


### PR DESCRIPTION
This option allow to use a file in the comparison but to ignore the
missing keys in that file.
This can be usefull when generating a file with all the translation keys
detected in the source code with a tool like ngx-translate-extract.